### PR TITLE
Fix warnings in FreeRTOS wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Why use it? FreeRTOS can be verbose and repetitive. These utilities keep your ap
 neat while remaining fully compatible with ESP‑IDF. From threads to queues and now timers,
 everything lives under one portable umbrella.
 
+Compatible with FreeRTOS kernel 11.1.x.
 Looking for guides? Head over to the [documentation index](docs/index.md).
 
 ## 📜 Table of Contents

--- a/docs/RTOSAbstraction.md
+++ b/docs/RTOSAbstraction.md
@@ -4,6 +4,7 @@
 
 `OsAbstraction` and `OsUtility` hide the direct FreeRTOS types behind a minimal interface. This makes it easier to port the component to other RTOSes in the future.
 
+This wrapper targets FreeRTOS kernel version 11.1.x and is designed to match its APIs.
 ## Highlights
 - Thin typedefs for tasks, queues and mutexes.
 - New stream buffer helpers for variable-length data.

--- a/include/OsAbstraction.h
+++ b/include/OsAbstraction.h
@@ -48,6 +48,18 @@ enum {
 static inline OS_Ulong os_time_get(void) { return xTaskGetTickCount(); }
 
 /* Thread wrappers ---------------------------------------------------------*/
+typedef struct {
+    void (*entry)(OS_Ulong);
+    OS_Ulong arg;
+} os_thread_start_t;
+
+static inline void os_thread_start_trampoline(void *p)
+{
+    os_thread_start_t params = *(os_thread_start_t *)p;
+    vPortFree(p);
+    params.entry(params.arg);
+}
+
 static inline OS_Uint os_thread_create(OS_Thread *t, const char *name,
                                        void (*entry)(OS_Ulong),
                                        OS_Ulong input, uint8_t *stack,
@@ -55,11 +67,20 @@ static inline OS_Uint os_thread_create(OS_Thread *t, const char *name,
                                        OS_Uint /*preempt*/, OS_Ulong /*slice*/,
                                        OS_Uint auto_start)
 {
-    BaseType_t res = xTaskCreate((TaskFunction_t)entry, name,
-                                 stack_size / sizeof(StackType_t),
-                                 (void *)input, priority, t);
-    if (res != pdPASS) return 1;
-    if (!auto_start) vTaskSuspend(*t);
+    os_thread_start_t *params =
+        (os_thread_start_t *)pvPortMalloc(sizeof(os_thread_start_t));
+    if (!params) return 1;
+    params->entry = entry;
+    params->arg = input;
+    BaseType_t res = xTaskCreate(os_thread_start_trampoline, name,
+                                 stack_size / sizeof(StackType_t), params,
+                                 priority, t);
+    if (res != pdPASS) {
+        vPortFree(params);
+        return 1;
+    }
+    if (!auto_start)
+        vTaskSuspend(*t);
     return OS_SUCCESS;
 }
 
@@ -69,7 +90,9 @@ static inline OS_Uint os_thread_delete(OS_Thread *t)   { vTaskDelete(*t);  retur
 static inline OS_Uint os_thread_terminate(OS_Thread *t){ vTaskDelete(*t);  return OS_SUCCESS; }
 static inline OS_Uint os_thread_info_get(OS_Thread *t, OS_Uint *state)
 {
-    if (state) *state = eTaskGetState(*t); return OS_SUCCESS;
+    if (state)
+        *state = eTaskGetState(*t);
+    return OS_SUCCESS;
 }
 static inline OS_Uint os_thread_sleep(OS_Ulong ticks)  { vTaskDelay(ticks); return OS_SUCCESS; }
 
@@ -93,7 +116,11 @@ static inline OS_Uint os_semaphore_delete(OS_Semaphore *s)   { vSemaphoreDelete(
 static inline OS_Uint os_semaphore_put(OS_Semaphore *s)      { return xSemaphoreGive(*s) ? OS_SUCCESS : 1; }
 static inline OS_Uint os_semaphore_get(OS_Semaphore *s, OS_Ulong wait) { return xSemaphoreTake(*s, wait) ? OS_SUCCESS : 1; }
 static inline OS_Uint os_semaphore_info_get(OS_Semaphore *s, OS_Ulong *count)
-{ if (count) *count = uxSemaphoreGetCount(*s); return OS_SUCCESS; }
+{
+    if (count)
+        *count = uxSemaphoreGetCount(*s);
+    return OS_SUCCESS;
+}
 
 /* Queue wrappers ---------------------------------------------------------*/
 static inline OS_Uint os_queue_create(OS_Queue *q, const char* /*name*/, OS_Uint item_words,
@@ -120,20 +147,50 @@ static inline OS_Uint os_event_group_get(OS_EventGroup *g, OS_Ulong flags, OS_Ui
 {
     EventBits_t bits = xEventGroupWaitBits(*g, flags, option == OS_AND,
                                            option == OS_AND, wait);
-    if (actual) *actual = bits; return OS_SUCCESS;
+    if (actual)
+        *actual = bits;
+    return OS_SUCCESS;
 }
 
 /* Timer wrappers ---------------------------------------------------------*/
+typedef struct {
+    void (*cb)(OS_Ulong);
+    OS_Ulong id;
+} os_timer_cb_t;
+
+static inline void os_timer_trampoline(TimerHandle_t timer)
+{
+    os_timer_cb_t *params = (os_timer_cb_t *)pvTimerGetTimerID(timer);
+    params->cb(params->id);
+}
+
 static inline OS_Uint os_timer_create(OS_Timer *t, const char *name,
                                       void (*cb)(OS_Ulong), OS_Ulong id,
                                       OS_Ulong initial, OS_Ulong reload,
                                       OS_Uint auto_act)
 {
-    *t = xTimerCreate(name, initial, reload != 0, (void *)id,
-                      (TimerCallbackFunction_t)cb);
-    if (!*t) return 1; if (auto_act) xTimerStart(*t, 0); return OS_SUCCESS;
+    os_timer_cb_t *params = (os_timer_cb_t *)pvPortMalloc(sizeof(os_timer_cb_t));
+    if (!params) return 1;
+    params->cb = cb;
+    params->id = id;
+
+    *t = xTimerCreate(name, initial, reload != 0, (void *)params,
+                      os_timer_trampoline);
+    if (!*t) {
+        vPortFree(params);
+        return 1;
+    }
+    if (auto_act)
+        xTimerStart(*t, 0);
+    return OS_SUCCESS;
 }
-static inline OS_Uint os_timer_delete(OS_Timer *t) { xTimerDelete(*t, 0); return OS_SUCCESS; }
+static inline OS_Uint os_timer_delete(OS_Timer *t)
+{
+    os_timer_cb_t *params = (os_timer_cb_t *)pvTimerGetTimerID(*t);
+    vPortFree(params);
+    xTimerDelete(*t, 0);
+    return OS_SUCCESS;
+}
 static inline OS_Uint os_timer_activate(OS_Timer *t)   { return xTimerStart(*t,0)==pdPASS ? OS_SUCCESS:1; }
 static inline OS_Uint os_timer_deactivate(OS_Timer *t) { return xTimerStop(*t,0)==pdPASS ? OS_SUCCESS:1; }
 


### PR DESCRIPTION
## Summary
- fix cast warnings in `OsAbstraction.h`
- resolve misleading indentation warnings
- document compatibility with FreeRTOS 11.1.x